### PR TITLE
Suvan integrate relief techniques with data storage

### DIFF
--- a/lib/components/ReliefActivitiesMenu/ActivitiesContainer.dart
+++ b/lib/components/ReliefActivitiesMenu/ActivitiesContainer.dart
@@ -5,6 +5,7 @@ import 'package:relieflink/utils/constants.dart';
 import '../../activities/activities.dart';
 import '../../utils/relief_technique_utils.dart';
 import 'ActivityButton.dart';
+import '../../utils/data_storage.dart';
 
 class ReliefActivityBoxContainer extends StatefulWidget {
   const ReliefActivityBoxContainer({Key? key}) : super(key: key);
@@ -20,20 +21,34 @@ class ReliefActivityBoxContainerState
   List<ReliefTechniqueData> activitiesList = activities;
   List<Widget> widgetList = [];
 
+  @override
+  void initState() {
+    super.initState();
+    List<ReliefTechniqueData>? data = DataStorage.getReliefTechniqueDataList();
+    if (data == null) {
+      DataStorage.init().then((success) {
+        activitiesList = DataStorage.getReliefTechniqueDataList()!;
+        setState(() {}); // Call build again
+      });
+    } else {
+      activitiesList = data;
+    }
+  }
+
   Widget buildBoxes(SearchAndSortOptions options) {
     var sort = options.sortOption;
     switch (sort) {
       case SortOptions.NONE:
         break;
       case SortOptions.FAVORITE:
-        activities.sort((a, b) => b.favorite ? 1 : -1);
+        activitiesList.sort((a, b) => b.favorite ? 1 : -1);
         break;
       case SortOptions.MOOD:
-        activities.sort(
+        activitiesList.sort(
             (a, b) => a.mood.toLowerCase().compareTo(b.mood.toLowerCase()));
         break;
       case SortOptions.TIME:
-        activities.sort((a, b) => a.duration - b.duration);
+        activitiesList.sort((a, b) => a.duration - b.duration);
         break;
       default:
     }

--- a/lib/components/ReliefActivitiesMenu/ActivityButton.dart
+++ b/lib/components/ReliefActivitiesMenu/ActivityButton.dart
@@ -1,4 +1,3 @@
-
 import 'package:flutter/material.dart';
 import 'package:relieflink/utils/constants.dart';
 
@@ -6,6 +5,7 @@ import '../../screens/ReliefHomeScreen.dart';
 import '../ReliefActivity/ReliefRateScreen.dart';
 import '../ReliefActivity/ReliefScreen.dart';
 import '../../utils/relief_technique_utils.dart';
+import '../../utils/data_storage.dart';
 
 class ActivityButton extends StatefulWidget {
   final ReliefTechniqueData activity;
@@ -83,6 +83,8 @@ class _ActivityButtonState extends State<ActivityButton> {
                   iconData =
                       iconData == Icons.star ? Icons.star_outline : Icons.star;
                 });
+                DataStorage.updateReliefTechniqueData(widget.activity);
+                DataStorage.saveToDisk();
               },
               icon: Icon(
                 iconData,

--- a/lib/utils/data_storage.dart
+++ b/lib/utils/data_storage.dart
@@ -13,7 +13,7 @@ class DataStorage {
 
   /// Initializes the local storage instance and updates the local copy of data.
   /// This function should be run before using a DataStorage object.
-  /// Beware of race conditions.
+  /// Beware of async bugs.
   /// Returns true if successful, false if unsuccessful
   static Future<bool> init() async {
     try {
@@ -52,7 +52,7 @@ class DataStorage {
         activityNames.add(activityData.activityName);
         setPair("relief_" + activityData.activityName, jsonEncode(activityData));
       }
-      setPair("applist_relief", activities);
+      setPair("applist_relief", activityNames);
     }
     return true;
   }
@@ -159,6 +159,19 @@ class DataStorage {
   static ReliefTechniqueData? getReliefTechniqueData(String activityName) {
     try {
       return ReliefTechniqueData.fromJson(jsonDecode(getValue("relief_" + activityName)));
+    } catch (e) {
+      return null;
+    }
+  }
+
+  static List<ReliefTechniqueData>? getReliefTechniqueDataList() {
+    try {
+      List reliefList = getValue("applist_relief");
+      List<ReliefTechniqueData> dataList = List.empty(growable: true);
+      for (String name in reliefList) {
+        dataList.add(getReliefTechniqueData(name)!);
+      }
+      return dataList;
     } catch (e) {
       return null;
     }

--- a/lib/utils/relief_technique_utils.dart
+++ b/lib/utils/relief_technique_utils.dart
@@ -11,6 +11,23 @@ class ReliefTechniqueData {
       required this.mood,
       required this.duration});
 
+  ReliefTechniqueData.fromJson(Map<String, dynamic> json):
+      videoLink = json['videoLink'],
+      activityName = json['activityName'],
+      mood = json['mood'],
+      favorite = json['favorite'],
+      duration = json['duration'];
+
+  Map<String, dynamic> toJson() {
+    return {
+      'videoLink': videoLink,
+      'activityName': activityName,
+      'mood': mood,
+      'favorite': favorite,
+      'duration': duration
+    };
+  }
+
   void toggleActivityFavorite() {
     favorite = !favorite;
   }


### PR DESCRIPTION
This PR stores relief technique data in local storage. This PR only connects the relief techniques menu page with the backend storage - a future PR will deal with the rating screen after the relief technique is complete.

After favoriting some relief techniques from the main page and restarting the application, the favorites are persistent and still work with the "Sort By Favorite" option. The below screenshot is the final result after favoriting three relief techniques, reopening the application, and sorting by favorite. (Red circles added afterwards to show the starred techniques, since it's somewhat hard to see with the overflow)

![Screenshot 2022-10-10 192605](https://user-images.githubusercontent.com/53096723/194967255-f47a5f7f-2774-44bd-95b0-bf8c7c16c628.png)

Note that the relief technique boxes are overflowing - this is not a new bug, but covered in issue #84.

No new bugs found.