### PR TITLE
Suvan integrate rating screen with data storage

### DIFF
--- a/lib/components/ReliefActivitiesMenu/ActivitiesContainer.dart
+++ b/lib/components/ReliefActivitiesMenu/ActivitiesContainer.dart
@@ -32,10 +32,11 @@ class ReliefActivityBoxContainerState
     if (data == null) {
       DataStorage.init().then((success) {
         activitiesList = DataStorage.getReliefTechniqueDataList()!;
-        setState(() {}); // Call build again
+        setState(() {});
       });
     } else {
       activitiesList = data;
+      setState(() {});
     }
   }
 

--- a/lib/components/ReliefActivitiesMenu/ActivitiesContainer.dart
+++ b/lib/components/ReliefActivitiesMenu/ActivitiesContainer.dart
@@ -24,6 +24,10 @@ class ReliefActivityBoxContainerState
   @override
   void initState() {
     super.initState();
+    updateActivities();
+  }
+
+  void updateActivities() {
     List<ReliefTechniqueData>? data = DataStorage.getReliefTechniqueDataList();
     if (data == null) {
       DataStorage.init().then((success) {
@@ -62,7 +66,8 @@ class ReliefActivityBoxContainerState
         widgetList.add(
           Padding(
               padding: const EdgeInsets.all(10.0),
-              child: ActivityButton(activity: activitiesList[i])),
+              child: ActivityButton(activity: activitiesList[i], updateParent: updateActivities)
+          ),
         );
       }
     }

--- a/lib/components/ReliefActivitiesMenu/ActivityButton.dart
+++ b/lib/components/ReliefActivitiesMenu/ActivityButton.dart
@@ -88,6 +88,7 @@ class _ActivityButtonState extends State<ActivityButton> {
                 });
                 DataStorage.updateReliefTechniqueData(widget.activity);
                 DataStorage.saveToDisk();
+                widget.updateParent();
               },
               icon: Icon(
                 iconData,

--- a/lib/components/ReliefActivitiesMenu/ActivityButton.dart
+++ b/lib/components/ReliefActivitiesMenu/ActivityButton.dart
@@ -9,7 +9,8 @@ import '../../utils/data_storage.dart';
 
 class ActivityButton extends StatefulWidget {
   final ReliefTechniqueData activity;
-  const ActivityButton({Key? key, required this.activity}) : super(key: key);
+  final Function updateParent;
+  const ActivityButton({Key? key, required this.activity, required this.updateParent}) : super(key: key);
 
   @override
   State<ActivityButton> createState() => _ActivityButtonState();
@@ -35,7 +36,9 @@ class _ActivityButtonState extends State<ActivityButton> {
         Navigator.push(
             context,
             MaterialPageRoute(
-                builder: (context) => ReliefScreen(data: widget.activity)));
+                builder: (context) => ReliefScreen(data: widget.activity)
+            )
+        ).then((success) => widget.updateParent()).then((success) => setState(() {}));
       },
       style: ButtonStyle(
           backgroundColor: MaterialStateProperty.all<Color>(AppColors.white),

--- a/lib/components/ReliefActivity/ReliefRateScreen.dart
+++ b/lib/components/ReliefActivity/ReliefRateScreen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:relieflink/utils/relief_technique_utils.dart';
 import 'package:relieflink/components/Navigation/TopBars.dart';
+import '../../utils/data_storage.dart';
 
 class ReliefRateScreen extends StatelessWidget {
   final ReliefTechniqueData data;
@@ -74,6 +75,7 @@ class RateButton extends StatelessWidget {
           primary: Colors.white, backgroundColor: Colors.orange),
       child: const Text("Rate"),
       onPressed: () {
+        DataStorage.saveToDisk();
         Navigator.pop(context);
         Navigator.pop(context);
       },
@@ -110,6 +112,7 @@ class _FavoriteButtonState extends State<FavoriteButton> {
 
   void flipFavorite() {
     widget.activity.toggleActivityFavorite();
+    DataStorage.updateReliefTechniqueData(widget.activity);
     setState(() {
       _favorite = !_favorite;
       if (_favorite) {

--- a/lib/components/ReliefActivity/ReliefRateScreen.dart
+++ b/lib/components/ReliefActivity/ReliefRateScreen.dart
@@ -75,7 +75,6 @@ class RateButton extends StatelessWidget {
           primary: Colors.white, backgroundColor: Colors.orange),
       child: const Text("Rate"),
       onPressed: () {
-        DataStorage.saveToDisk();
         Navigator.pop(context);
         Navigator.pop(context);
       },
@@ -100,6 +99,7 @@ class _FavoriteButtonState extends State<FavoriteButton> {
 
   @override
   void initState() {
+    super.initState();
     _favorite = widget.activity.favorite;
     if (_favorite) {
       _iconData = Icons.star;
@@ -113,6 +113,7 @@ class _FavoriteButtonState extends State<FavoriteButton> {
   void flipFavorite() {
     widget.activity.toggleActivityFavorite();
     DataStorage.updateReliefTechniqueData(widget.activity);
+    DataStorage.saveToDisk();
     setState(() {
       _favorite = !_favorite;
       if (_favorite) {


### PR DESCRIPTION
### Features
This PR makes it so that changes to the star rating done in the relief technique rate screen (after the technique is performed) are stored, so they persist after application close.

It also makes the change in star rating apply to the main page after moving back from the rating page, including allowing sort by favorite to work as intended (i.e. if the activity is favorited during the rating screen, it moves to the top when you come back to the page, and similarly if it is unfavorited).

Similarly, this PR also makes the main relief techniques page immediately update if a relief technique is favorited.

### Bugs
No new bugs found in this PR.