### PR TITLE
Jess 101 restyle recommendations screen

### DIFF
--- a/lib/recommendations/RecommendationScreen.dart
+++ b/lib/recommendations/RecommendationScreen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:relieflink/recommendations/recommendations.dart';
+import 'package:relieflink/screens/MeScreen.dart';
 import 'package:store_redirect/store_redirect.dart';
 
 import '../utils/constants.dart';
@@ -15,21 +16,13 @@ class RecommendationScreen extends StatelessWidget {
       home: Scaffold(
         backgroundColor: AppColors.bg,
         body: ListView(
-          padding: const EdgeInsets.only(left: 380.0, right: 380.0),
+          padding: const EdgeInsets.only(left: 10.0, right: 10.0),
           //adjust the paddings from the two edges
           children: [
             const SizedBox(
-              height: 60,
+              height: 80,
             ),
-            Text(
-              "Other Recommended Apps",
-              textAlign: TextAlign.center,
-              overflow: TextOverflow.ellipsis,
-              style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 26),
-            ),
-            const SizedBox(
-              height: 30,
-            ),
+            backButton(context),
             recommendationButton(0),
             recommendationButton(1),
             recommendationButton(2),
@@ -43,42 +36,109 @@ class RecommendationScreen extends StatelessWidget {
     );
   }
 
+  Widget backButton(BuildContext context) {
+    return (MaterialButton(
+      onPressed: () {
+        Navigator.push(
+            context, MaterialPageRoute(builder: (context) => (MeScreen())));
+      },
+      child: Row(
+        children: [
+          IconButton(
+              icon: Icon(Icons.chevron_left_outlined),
+              iconSize: 30,
+              onPressed: () {
+                Navigator.push(context,
+                    MaterialPageRoute(builder: (context) => (MeScreen())));
+              }),
+          Text(
+            "Back",
+            textAlign: TextAlign.center,
+            style: const TextStyle(
+              color: AppColors.black,
+              fontSize: 20,
+            ),
+          ),
+        ],
+      ),
+    ));
+  }
+
   Widget recommendationButton(int index) {
+    LinearGradient grad = AppConstants.getGradByMood("blue");
+    Color color = AppConstants.getColorByMood("cyan");
+    const double radius = 10;
+    double buttonMinHeight = 120;
+
     return Padding(
-      padding: const EdgeInsets.only(bottom: 40),
-      child: (MaterialButton(
-        color: AppColors.green,
-        height: 70.0,
-        minWidth: 70.0,
+      padding: const EdgeInsets.only(bottom: 10),
+      child: (ElevatedButton(
         onPressed: () {
           StoreRedirect.redirect(
             androidAppId: androidAppId,
             iOSAppId: iOSAppId,
           );
         },
+        style: ButtonStyle(
+            backgroundColor: MaterialStateProperty.all<Color>(AppColors.white),
+            shape: MaterialStateProperty.all<RoundedRectangleBorder>(
+              const RoundedRectangleBorder(
+                  borderRadius: BorderRadius.all(Radius.circular(radius))),
+            ),
+            padding: MaterialStateProperty.all<EdgeInsets>(EdgeInsets.all(0)),
+            fixedSize:
+                MaterialStateProperty.all<Size>(Size(0, buttonMinHeight)),
+            alignment: Alignment.centerLeft),
         child: Row(
+          mainAxisAlignment: MainAxisAlignment.start,
+          crossAxisAlignment: CrossAxisAlignment.center,
           children: [
-            IconButton(
-              icon: recommendations[index].icon,
-              onPressed: () {},
-              padding: EdgeInsets.only(right: 15),
-            ),
-            Text(
-              recommendations[index].title,
-              style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
-              overflow: TextOverflow.clip,
-            ),
             SizedBox(
               width: 15,
             ),
-            Flexible(
-                child: Text(
-              recommendations[index].description,
-              style: const TextStyle(
-                fontSize: 20,
+            SizedBox(
+              height: 120,
+              width: 300,
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    recommendations[index].title,
+                    textAlign: TextAlign.center,
+                    style: const TextStyle(
+                      color: AppColors.font,
+                      fontFamily: 'MainFont',
+                      fontWeight: FontWeight.w800,
+                      fontSize: 18,
+                    ),
+                    overflow: TextOverflow.clip,
+                  ),
+                  SizedBox(
+                    height: 5,
+                  ),
+                  Text(
+                    recommendations[index].description,
+                    style: const TextStyle(
+                      color: AppColors.font,
+                      fontFamily: 'MainFont',
+                      fontSize: 14,
+                    ),
+                    overflow: TextOverflow.clip,
+                  ),
+                ],
               ),
-              overflow: TextOverflow.clip,
-            ))
+            ),
+            IconButton(
+              color: AppColors.font,
+              icon: Icon(Icons.arrow_circle_right_outlined),
+              onPressed: () {
+                StoreRedirect.redirect(
+                  androidAppId: androidAppId,
+                  iOSAppId: iOSAppId,
+                );
+              },
+            ),
           ],
         ),
       )),

--- a/lib/screens/MeScreen.dart
+++ b/lib/screens/MeScreen.dart
@@ -21,15 +21,15 @@ class MeScreen extends StatelessWidget {
             ),
             meScreenButton(context, "Profile"),
             const SizedBox(
-              height: 60,
+              height: 20,
             ),
             meScreenButton(context, "Recommendations"),
             const SizedBox(
-              height: 60,
+              height: 20,
             ),
             meScreenButton(context, "Find a Health Care Center Near You"),
             const SizedBox(
-              height: 60,
+              height: 20,
             ),
             meScreenButton(context, "Onboarding")
           ],
@@ -44,11 +44,11 @@ class MeScreen extends StatelessWidget {
     switch (screenName) {
       case "Profile":
         goto = ProfileScreen();
-        screenIcon = Icons.account_circle;
+        screenIcon = Icons.account_circle_outlined;
         break;
       case "Recommendations":
         goto = RecommendationScreen();
-        screenIcon = Icons.airline_stops;
+        screenIcon = Icons.star_border_outlined;
         break;
       case "Find a Health Care Center Near You":
         goto = MapScreen();
@@ -56,30 +56,59 @@ class MeScreen extends StatelessWidget {
         break;
       case "Onboarding":
         goto = OnboardingScreen();
-        screenIcon = Icons.offline_bolt_sharp;
+        screenIcon = Icons.offline_bolt_outlined;
         break;
     }
+
+    LinearGradient grad = AppConstants.getGradByMood("blue");
+    Color color = AppConstants.getColorByMood("cyan");
+    const double radius = 10;
+    double buttonMinHeight = 60;
+
     return Padding(
-      padding: const EdgeInsets.only(bottom: 40),
-      child: (MaterialButton(
-        color: AppColors.orange,
-        height: 80.0,
-        minWidth: 70.0,
+      padding: const EdgeInsets.only(bottom: 10),
+      child: (ElevatedButton(
         onPressed: () {
           Navigator.push(
               context, MaterialPageRoute(builder: (context) => (goto)));
         },
-        child: Row(
-          children: [
-            Icon(screenIcon),
-            SizedBox(
-              width: 30,
+        style: ButtonStyle(
+            backgroundColor: MaterialStateProperty.all<Color>(AppColors.white),
+            shape: MaterialStateProperty.all<RoundedRectangleBorder>(
+              const RoundedRectangleBorder(
+                  borderRadius: BorderRadius.all(Radius.circular(radius))),
             ),
-            Flexible(
-                child: Text(
-              "${screenName}",
-              style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
-            )),
+            padding: MaterialStateProperty.all<EdgeInsets>(EdgeInsets.all(0)),
+            fixedSize:
+                MaterialStateProperty.all<Size>(Size(0, buttonMinHeight)),
+            alignment: Alignment.centerLeft),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.start,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            IconButton(
+                color: AppColors.font,
+                onPressed: () {},
+                icon: Icon(
+                  screenIcon,
+                  size: 20,
+                )),
+            Text("${screenName}",
+                textAlign: TextAlign.center,
+                style: const TextStyle(
+                  color: AppColors.font,
+                  fontFamily: 'MainFont',
+                  fontWeight: FontWeight.w800,
+                  fontSize: 16,
+                )),
+            Spacer(),
+            IconButton(
+                color: AppColors.font,
+                onPressed: () {},
+                icon: Icon(
+                  Icons.arrow_forward_ios_outlined,
+                  size: 20,
+                )),
           ],
         ),
       )),

--- a/lib/screens/MeScreen.dart
+++ b/lib/screens/MeScreen.dart
@@ -39,7 +39,7 @@ class MeScreen extends StatelessWidget {
   }
 
   Widget meScreenButton(BuildContext context, String screenName) {
-    Widget goto = ProfileScreen();
+    Widget goto = MeScreen();
     IconData screenIcon = Icons.account_circle;
     switch (screenName) {
       case "Profile":
@@ -69,6 +69,7 @@ class MeScreen extends StatelessWidget {
       padding: const EdgeInsets.only(bottom: 10),
       child: (ElevatedButton(
         onPressed: () {
+          print(goto);
           Navigator.push(
               context, MaterialPageRoute(builder: (context) => (goto)));
         },
@@ -104,7 +105,10 @@ class MeScreen extends StatelessWidget {
             Spacer(),
             IconButton(
                 color: AppColors.font,
-                onPressed: () {},
+                onPressed: () {
+                  Navigator.push(
+                      context, MaterialPageRoute(builder: (context) => (goto)));
+                },
                 icon: Icon(
                   Icons.arrow_forward_ios_outlined,
                   size: 20,

--- a/lib/screens/MeScreen.dart
+++ b/lib/screens/MeScreen.dart
@@ -69,7 +69,6 @@ class MeScreen extends StatelessWidget {
       padding: const EdgeInsets.only(bottom: 10),
       child: (ElevatedButton(
         onPressed: () {
-          print(goto);
           Navigator.push(
               context, MaterialPageRoute(builder: (context) => (goto)));
         },

--- a/lib/screens/NavigationWrapper.dart
+++ b/lib/screens/NavigationWrapper.dart
@@ -28,17 +28,16 @@ class _NavState extends State<Nav> {
   Widget build(BuildContext context) {
     return Scaffold(
         //state within screens are maintained
-      floatingActionButton: FloatingActionButton(
-        child: const Icon(Icons.local_florist), //icon ideas: balance cloud crisis_alert emergency_sharp foggy front_hand handshake healing health_and_safety
-        onPressed: () {
-          Navigator.push(
-            context,
-            MaterialPageRoute(
-              builder: (context) => CrisisPlan()));
-        },
-      ),
-      floatingActionButtonLocation:
-        FloatingActionButtonLocation.centerDocked,
+        floatingActionButton: FloatingActionButton(
+          heroTag: null,
+          child: const Icon(Icons
+              .local_florist), //icon ideas: balance cloud crisis_alert emergency_sharp foggy front_hand handshake healing health_and_safety
+          onPressed: () {
+            Navigator.push(
+                context, MaterialPageRoute(builder: (context) => CrisisPlan()));
+          },
+        ),
+        floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
         body: IndexedStack(
           index: currentIndex,
           children: screens,


### PR DESCRIPTION
> Function: Reframing the recommendation buttons and meScreen buttons.

> Files Changed: lib/recommendations/RecommendationScreen.dart, lib/screens/MeScreen.dart, lib/screens/NavigationWrapper.dart

> Existing Issues: 
(1) sometimes the button to the profile screen is not working. 
(2) as suggested in Figma design, there should be top and bottom bars for the recommendation screen, which I'm not sure how to implement into current build.

> Issues with other screens to mind:
Opening the map screen will lead to a shutdown of the application.

> Screenshots:
<img width="341" alt="Screenshot 2022-11-27 at 21 56 50" src="https://user-images.githubusercontent.com/90209286/204182609-c5a528c2-7762-46fd-a9db-32e2fb135763.png">
<img width="344" alt="Screenshot 2022-11-27 at 21 57 01" src="https://user-images.githubusercontent.com/90209286/204182661-e74a8a5a-1719-43bf-8a9c-cde59556610e.png">
